### PR TITLE
Update Streaming-Chapter_21_Structured_Streaming_Basics.scala

### DIFF
--- a/code/Streaming-Chapter_21_Structured_Streaming_Basics.scala
+++ b/code/Streaming-Chapter_21_Structured_Streaming_Basics.scala
@@ -146,7 +146,7 @@ val socketDF = spark.readStream.format("socket")
 
 // COMMAND ----------
 
-activityCounts.format("console").write()
+activityCounts.writeStream.format("console").start()
 
 
 // COMMAND ----------


### PR DESCRIPTION
Value format is not a member of org.apache.spark.sql.DataFrame